### PR TITLE
feat(grabcut): add resize functionality with multiple scaling methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,59 @@ Load Images (Batch) → TransparencyBackgroundRemover → Save Images
 
 ---
 
+## 🎯 Auto GrabCut Background Remover
+
+### Overview
+The **Auto GrabCut Background Remover** node provides advanced object detection and segmentation using YOLO and GrabCut algorithms. It can automatically detect objects in images and remove backgrounds with high precision, or refine existing masks for better quality.
+
+### Key Features
+- **Automatic Object Detection**: Uses YOLO to identify objects (person, product, vehicle, animal, furniture, electronics)
+- **GrabCut Refinement**: Advanced segmentation algorithm for precise edge detection
+- **Resize Functionality**: Scale output to preset or custom dimensions
+- **Multiple Scaling Methods**: NEAREST (pixel-perfect), BILINEAR, BICUBIC, LANCZOS
+- **Mask Refinement**: Improve existing masks from other background removal tools
+
+### Node Parameters
+
+#### Auto GrabCut Remover
+
+| Parameter | Type | Range/Options | Default | Description |
+|-----------|------|---------------|---------|-------------|
+| **object_class** | DROPDOWN | auto, person, product, vehicle, animal, furniture, electronics | auto | Target object class for detection |
+| **confidence_threshold** | FLOAT | 0.3-0.9 | 0.5 | Minimum confidence for object detection |
+| **grabcut_iterations** | INT | 1-10 | 5 | Number of GrabCut algorithm iterations |
+| **margin_pixels** | INT | 0-50 | 20 | Pixel margin around detected object |
+| **edge_refinement** | FLOAT | 0.0-1.0 | 0.7 | Edge refinement strength (0=none, 1=maximum) |
+| **binary_threshold** | INT | 128-250 | 200 | Threshold for binary mask conversion |
+| **output_size** | DROPDOWN | ORIGINAL, 512x512, 1024x1024, 2048x2048, custom | ORIGINAL | Target output dimensions |
+| **scaling_method** | DROPDOWN | NEAREST, BILINEAR, BICUBIC, LANCZOS | NEAREST | Interpolation method for scaling |
+| **output_format** | DROPDOWN | RGBA, MASK | RGBA | Output format type |
+
+#### Optional Parameters
+| Parameter | Type | Range | Default | Description |
+|-----------|------|-------|---------|-------------|
+| **initial_mask** | MASK | - | - | Initial mask from previous processing |
+| **custom_width** | INT | 64-4096 | 512 | Custom width (when output_size is 'custom') |
+| **custom_height** | INT | 64-4096 | 512 | Custom height (when output_size is 'custom') |
+
+### Usage Examples
+
+#### Basic Object Removal
+1. Connect your image to the Auto GrabCut node
+2. Select the appropriate `object_class` (or leave as "auto")
+3. Adjust `confidence_threshold` if needed
+4. Choose your desired `output_size` and `scaling_method`
+5. Run the workflow
+
+#### Mask Refinement
+Use the **GrabCut Refinement** node to improve masks from other sources:
+1. Connect an image and its existing mask
+2. Adjust `grabcut_iterations` for refinement quality
+3. Set `edge_refinement` for smoothing
+4. Apply resize options if needed
+
+---
+
 ## 🔧 Technical Details
 
 ### Supported Image Formats

--- a/grabcut_nodes.py
+++ b/grabcut_nodes.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 from typing import Tuple, Optional
 import time
+from PIL import Image
 
 # Try to import ComfyUI modules
 try:
@@ -68,12 +69,34 @@ class AutoGrabCutRemover:
                     "step": 10,
                     "tooltip": "Threshold for binary mask conversion"
                 }),
+                "output_size": (["ORIGINAL", "512x512", "1024x1024", "2048x2048", "custom"], {
+                    "default": "ORIGINAL",
+                    "tooltip": "Target output size for the processed image and mask"
+                }),
+                "scaling_method": (["NEAREST", "BILINEAR", "BICUBIC", "LANCZOS"], {
+                    "default": "NEAREST",
+                    "tooltip": "Interpolation method for scaling: NEAREST (pixel-perfect), BILINEAR (smooth), BICUBIC (high-quality), LANCZOS (best quality)"
+                }),
             },
             "optional": {
                 "initial_mask": ("MASK",),
                 "output_format": (["RGBA", "MASK"], {
                     "default": "RGBA",
                     "tooltip": "Output format: RGBA with alpha channel or binary MASK (0=background, 255=foreground)"
+                }),
+                "custom_width": ("INT", {
+                    "default": 512,
+                    "min": 64,
+                    "max": 4096,
+                    "step": 8,
+                    "tooltip": "Custom width (used when output_size is 'custom')"
+                }),
+                "custom_height": ("INT", {
+                    "default": 512,
+                    "min": 64,
+                    "max": 4096,
+                    "step": 8,
+                    "tooltip": "Custom height (used when output_size is 'custom')"
                 }),
             }
         }
@@ -97,6 +120,99 @@ class AutoGrabCutRemover:
             print("Using fallback processor without YOLO")
             self.processor = create_fallback_processor()()
     
+    def parse_output_size(self, size_string: str) -> Optional[Tuple[int, int]]:
+        """
+        Parse output size string to width, height tuple.
+        
+        Args:
+            size_string: String like "512x512" or "ORIGINAL" or "custom"
+            
+        Returns:
+            Tuple (width, height) or None for ORIGINAL
+        """
+        if size_string == "ORIGINAL":
+            return None
+        elif size_string == "custom":
+            return None  # Will be handled with custom_width/custom_height
+        
+        try:
+            width, height = size_string.split('x')
+            return (int(width), int(height))
+        except ValueError:
+            raise ValueError(f"Invalid output size format: {size_string}")
+    
+    def calculate_scaling_factor(self, current_size: Tuple[int, int], target_size: Tuple[int, int]) -> float:
+        """
+        Calculate optimal scaling factor.
+        
+        Args:
+            current_size: Tuple (width, height) of current image
+            target_size: Tuple (width, height) of target size
+            
+        Returns:
+            Scaling factor that achieves target size
+        """
+        current_w, current_h = current_size
+        target_w, target_h = target_size
+        
+        # Calculate scale factors for width and height
+        scale_w = target_w / current_w
+        scale_h = target_h / current_h
+        
+        # Use the same scale for both dimensions to maintain aspect ratio
+        # Choose the smaller scale to ensure we don't exceed target dimensions
+        scale_factor = min(scale_w, scale_h)
+        
+        return scale_factor
+    
+    def intelligent_scale(self, image_pil: Image.Image, target_size: Tuple[int, int], scaling_method: str = "NEAREST") -> Image.Image:
+        """
+        Scale image to target dimensions using specified interpolation method.
+        
+        Args:
+            image_pil: PIL Image object
+            target_size: Tuple (width, height) for target dimensions
+            scaling_method: Interpolation method ("NEAREST", "BILINEAR", "BICUBIC", "LANCZOS")
+            
+        Returns:
+            Scaled PIL Image
+        """
+        if target_size is None:
+            return image_pil
+            
+        current_size = (image_pil.width, image_pil.height)
+        target_w, target_h = target_size
+        
+        # If already at target size, return as-is
+        if current_size == target_size:
+            return image_pil
+        
+        # Calculate scaling factor
+        scale_factor = self.calculate_scaling_factor(current_size, target_size)
+        
+        # Apply scaling
+        new_width = int(image_pil.width * scale_factor)
+        new_height = int(image_pil.height * scale_factor)
+        
+        # If calculated size matches target exactly, use target dimensions
+        if abs(new_width - target_w) <= 1 and abs(new_height - target_h) <= 1:
+            new_width, new_height = target_w, target_h
+        
+        # Select resampling method based on scaling_method
+        resampling_map = {
+            "NEAREST": Image.Resampling.NEAREST,
+            "BILINEAR": Image.Resampling.BILINEAR, 
+            "BICUBIC": Image.Resampling.BICUBIC,
+            "LANCZOS": Image.Resampling.LANCZOS
+        }
+        
+        resampling_method = resampling_map.get(scaling_method, Image.Resampling.NEAREST)
+        
+        return image_pil.resize(
+            (new_width, new_height),
+            resampling_method
+        )
+    
     def _map_object_class(self, object_class: str) -> Optional[str]:
         """Map UI object class to YOLO class names."""
         mapping = {
@@ -116,8 +232,12 @@ class AutoGrabCutRemover:
                          margin_pixels: int = 20,
                          edge_refinement: float = 0.7,
                          binary_threshold: int = 200,
+                         output_size: str = "ORIGINAL",
+                         scaling_method: str = "NEAREST",
                          initial_mask: Optional[torch.Tensor] = None,
-                         output_format: str = "RGBA") -> Tuple:
+                         output_format: str = "RGBA",
+                         custom_width: int = 512,
+                         custom_height: int = 512) -> Tuple:
         """
         Process image with automated GrabCut background removal.
         
@@ -201,8 +321,25 @@ class AutoGrabCutRemover:
                     # Convert RGBA result back to tensor format
                     rgba = result['rgba_image']
                     
+                    # Apply resize if requested
+                    if output_size != "ORIGINAL":
+                        # Parse target dimensions
+                        if output_size == "custom":
+                            target_dimensions = (custom_width, custom_height)
+                        else:
+                            target_dimensions = self.parse_output_size(output_size)
+                        
+                        if target_dimensions is not None:
+                            # Convert to PIL Image for scaling
+                            rgba_pil = Image.fromarray(rgba, 'RGBA')
+                            
+                            # Apply intelligent scaling with specified method
+                            rgba_scaled = self.intelligent_scale(rgba_pil, target_dimensions, scaling_method)
+                            
+                            # Convert back to numpy
+                            rgba = np.array(rgba_scaled)
+                    
                     # Separate RGB and alpha
-                    rgb = rgba[:, :, :3].astype(np.float32) / 255.0
                     alpha = rgba[:, :, 3].astype(np.float32) / 255.0
                     
                     if output_format == "RGBA":
@@ -327,6 +464,30 @@ class GrabCutRefinement:
                     "step": 5,
                     "tooltip": "Pixels to expand mask boundary"
                 }),
+                "output_size": (["ORIGINAL", "512x512", "1024x1024", "2048x2048", "custom"], {
+                    "default": "ORIGINAL",
+                    "tooltip": "Target output size for the refined image and mask"
+                }),
+                "scaling_method": (["NEAREST", "BILINEAR", "BICUBIC", "LANCZOS"], {
+                    "default": "NEAREST",
+                    "tooltip": "Interpolation method for scaling"
+                }),
+            },
+            "optional": {
+                "custom_width": ("INT", {
+                    "default": 512,
+                    "min": 64,
+                    "max": 4096,
+                    "step": 8,
+                    "tooltip": "Custom width (used when output_size is 'custom')"
+                }),
+                "custom_height": ("INT", {
+                    "default": 512,
+                    "min": 64,
+                    "max": 4096,
+                    "step": 8,
+                    "tooltip": "Custom height (used when output_size is 'custom')"
+                }),
             }
         }
     
@@ -347,10 +508,72 @@ class GrabCutRefinement:
         except Exception:
             self.processor = create_fallback_processor()(iterations=3)
     
+    def parse_output_size(self, size_string: str) -> Optional[Tuple[int, int]]:
+        """Parse output size string to width, height tuple."""
+        if size_string == "ORIGINAL":
+            return None
+        elif size_string == "custom":
+            return None
+        
+        try:
+            width, height = size_string.split('x')
+            return (int(width), int(height))
+        except ValueError:
+            raise ValueError(f"Invalid output size format: {size_string}")
+    
+    def calculate_scaling_factor(self, current_size: Tuple[int, int], target_size: Tuple[int, int]) -> float:
+        """Calculate optimal scaling factor."""
+        current_w, current_h = current_size
+        target_w, target_h = target_size
+        
+        scale_w = target_w / current_w
+        scale_h = target_h / current_h
+        
+        scale_factor = min(scale_w, scale_h)
+        
+        return scale_factor
+    
+    def intelligent_scale(self, image_pil: Image.Image, target_size: Tuple[int, int], scaling_method: str = "NEAREST") -> Image.Image:
+        """Scale image to target dimensions using specified interpolation method."""
+        if target_size is None:
+            return image_pil
+            
+        current_size = (image_pil.width, image_pil.height)
+        target_w, target_h = target_size
+        
+        if current_size == target_size:
+            return image_pil
+        
+        scale_factor = self.calculate_scaling_factor(current_size, target_size)
+        
+        new_width = int(image_pil.width * scale_factor)
+        new_height = int(image_pil.height * scale_factor)
+        
+        if abs(new_width - target_w) <= 1 and abs(new_height - target_h) <= 1:
+            new_width, new_height = target_w, target_h
+        
+        resampling_map = {
+            "NEAREST": Image.Resampling.NEAREST,
+            "BILINEAR": Image.Resampling.BILINEAR, 
+            "BICUBIC": Image.Resampling.BICUBIC,
+            "LANCZOS": Image.Resampling.LANCZOS
+        }
+        
+        resampling_method = resampling_map.get(scaling_method, Image.Resampling.NEAREST)
+        
+        return image_pil.resize(
+            (new_width, new_height),
+            resampling_method
+        )
+    
     def refine_mask(self, image: torch.Tensor, mask: torch.Tensor,
                    grabcut_iterations: int = 3,
                    edge_refinement: float = 0.5,
-                   expand_margin: int = 10) -> Tuple:
+                   expand_margin: int = 10,
+                   output_size: str = "ORIGINAL",
+                   scaling_method: str = "NEAREST",
+                   custom_width: int = 512,
+                   custom_height: int = 512) -> Tuple:
         """
         Refine existing mask using GrabCut.
         
@@ -398,6 +621,25 @@ class GrabCutRefinement:
             
             if result['success']:
                 rgba = result['rgba_image']
+                
+                # Apply resize if requested
+                if output_size != "ORIGINAL":
+                    # Parse target dimensions
+                    if output_size == "custom":
+                        target_dimensions = (custom_width, custom_height)
+                    else:
+                        target_dimensions = self.parse_output_size(output_size)
+                    
+                    if target_dimensions is not None:
+                        # Convert to PIL Image for scaling
+                        rgba_pil = Image.fromarray(rgba, 'RGBA')
+                        
+                        # Apply intelligent scaling with specified method
+                        rgba_scaled = self.intelligent_scale(rgba_pil, target_dimensions, scaling_method)
+                        
+                        # Convert back to numpy
+                        rgba = np.array(rgba_scaled)
+                
                 rgb = rgba[:, :, :3].astype(np.float32) / 255.0
                 alpha = rgba[:, :, 3].astype(np.float32) / 255.0
                 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ComfyUI-TransparencyBackgroundRemover"
-version = "1.0.4"
+version = "1.1.0"
 description = "Automatic background removal and transparency generation for ComfyUI"
 license = { file = "LICENSE" }
 requires-python = ">=3.8"


### PR DESCRIPTION
   - Added output_size parameter with options: ORIGINAL, 512x512, 1024x1024, 2048x2048, custom
   - Added scaling_method parameter with NEAREST, BILINEAR, BICUBIC, LANCZOS options
   - Implemented custom width/height inputs for custom output size
   - Added intelligent scaling logic that maintains aspect ratio
   - Updated both AutoGrabCutRemover and GrabCutRefinement nodes
   - Maintained backward compatibility with existing workflows