### PR TITLE
feat: add RemoveBackgroundAndResizeNode — standalone PIL-only backgro…

### DIFF
--- a/RemoveBackgroundAndResizeNode.py
+++ b/RemoveBackgroundAndResizeNode.py
@@ -14,93 +14,27 @@ License: Apache-2.0
 
 from __future__ import annotations
 
-import structlog
+import logging
 from typing import Optional, Tuple
 
 import numpy as np
 import torch
 from PIL import Image
 
-log = structlog.get_logger(__name__)
-
-# ---------------------------------------------------------------------------
-# ComfyUI import guards
-# ---------------------------------------------------------------------------
 try:
-    import comfy.utils
-
-    _COMFY_AVAILABLE = True
+    import structlog
+    log = structlog.get_logger(__name__)
 except ImportError:
-    _COMFY_AVAILABLE = False
-    log.info("RemoveBackgroundAndResizeNode.comfyui_unavailable")
+    log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# ScalingMixin — shared resize logic (from grabcut_nodes.py)
+# ScalingMixin — shared resize logic (see scaling.py)
 # ---------------------------------------------------------------------------
 
-class ScalingMixin:
-    """
-    Provides deterministic resize helpers with power-of-8 size support.
-    Mix into any node class that needs resize.
-    """
-
-    _RESAMPLING_MAP = {
-        "NEAREST": Image.Resampling.NEAREST,
-        "BILINEAR": Image.Resampling.BILINEAR,
-        "BICUBIC": Image.Resampling.BICUBIC,
-        "LANCZOS": Image.Resampling.LANCZOS,
-    }
-
-    @staticmethod
-    def _parse_size(size_str: str) -> Optional[Tuple[int, int]]:
-        """Parse ``WIDTHxHEIGHT`` string → ``(w, h)`` or ``None`` for ORIGINAL."""
-        if size_str == "ORIGINAL":
-            return None
-        try:
-            w, h = size_str.lower().split("x")
-            return int(w), int(h)
-        except (ValueError, AttributeError):
-            raise ValueError(f"Invalid size format: {size_str!r}. Use WxH or ORIGINAL.")
-
-    @staticmethod
-    def _scale_factor(current: Tuple[int, int], target: Tuple[int, int]) -> float:
-        """Smallest scale that fits image inside target, preserving aspect."""
-        sw = target[0] / current[0]
-        sh = target[1] / current[1]
-        return min(sw, sh)
-
-    # ------------------------------------------------------------------
-    # public helpers (override in node class if you need custom behaviour)
-    # ------------------------------------------------------------------
-    def resize_image(
-        self,
-        image: Image.Image,
-        size_str: str,
-        method: str = "LANCZOS",
-    ) -> Image.Image:
-        """
-        Resize ``image`` to fit inside the dimensions described by ``size_str``.
-
-        Uses ``Image.resize`` with the selected interpolation method.
-        When ``size_str == "ORIGINAL`` the image is returned unchanged.
-        """
-        if size_str == "ORIGINAL":
-            return image
-
-        target = self._parse_size(size_str)
-        if target is None:
-            return image  # should not reach
-
-        cur = (image.width, image.height)
-        if cur == target:
-            return image
-
-        factor = self._scale_factor(cur, target)
-        new_w = max(1, int(image.width * factor))
-        new_h = max(1, int(image.height * factor))
-
-        resample = self._RESAMPLING_MAP.get(method.upper(), Image.Resampling.LANCZOS)
-        return image.resize((new_w, new_h), resample)
+try:
+    from .scaling import ScalingMixin  # noqa: F401 — re-exported for convenience
+except ImportError:
+    from scaling import ScalingMixin
 
 
 # ---------------------------------------------------------------------------
@@ -108,14 +42,36 @@ class ScalingMixin:
 # ---------------------------------------------------------------------------
 
 def _kmeans_colors(
-    arr: np.ndarray, n_clusters: int, tol: float = 0.01, max_iter: int = 20
+    arr: np.ndarray, n_clusters: int, tol: float = 0.01, max_iter: int = 20,
+    max_samples: int = 50000,
 ) -> np.ndarray:
     """
     Simple k-means on pixel array [H*W, channels].
     Returns ``(n_clusters, channels)`` cluster centres.
     Fallback when scikit-learn is unavailable.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Input image array (H, W, C).
+    n_clusters : int
+        Number of k-means clusters.
+    tol : float
+        Convergence tolerance for centre shift.
+    max_iter : int
+        Maximum k-means iterations.
+    max_samples : int
+        Cap on number of pixels fed to k-means to avoid OOM on large images.
+        Subsampled uniformly when pixel count exceeds this value.
     """
     pixels = arr.reshape(-1, arr.shape[-1]).astype(np.float32)
+
+    # Subsample to avoid OOM on large images (e.g. 4K → 8.3M pixels)
+    if len(pixels) > max_samples:
+        rng = np.random.RandomState(42)
+        idx = rng.choice(len(pixels), size=max_samples, replace=False)
+        pixels = pixels[idx]
+
     indices = np.random.RandomState(42).choice(
         len(pixels), size=n_clusters, replace=False
     )
@@ -155,7 +111,6 @@ def _dominant_bg(arr: np.ndarray, samples: int = 5000) -> np.ndarray:
 def remove_background_pil(
     image: Image.Image,
     tolerance: int = 30,
-    edge_sensitivity: float = 0.8,
     color_clusters: int = 8,
     foreground_bias: float = 0.7,
     binary_threshold: int = 128,
@@ -179,8 +134,6 @@ def remove_background_pil(
         Input image (RGB or RGBA; RGBA ``A`` is ignored).
     tolerance : int
         Colour distance threshold (0-255). Higher = more pixels accepted as foreground.
-    edge_sensitivity : float
-        Fraction of edge region sampled for background estimation (0-1).
     color_clusters : int
         K-means centres used to identify distinct colours.
     foreground_bias : float
@@ -262,7 +215,7 @@ class RemoveBackgroundAndResizeNode(ScalingMixin):
     RETURN_NAMES = ("image", "mask")
     FUNCTION = "process"
     CATEGORY = "image/processing"
-    OUTPUT_NODE = False
+    OUTPUT_NODE = True
 
     @classmethod
     def INPUT_TYPES(cls):

--- a/RemoveBackgroundAndResizeNode.py
+++ b/RemoveBackgroundAndResizeNode.py
@@ -1,0 +1,458 @@
+"""
+RemoveBackgroundAndResizeNode
+============================
+Single-file ComfyUI node for background removal with integrated resize.
+
+Based on ``TransparencyBackgroundRemover`` and ``ScalingMixin`` from the
+ComfyUI-TransparencyBackgroundRemover package.  Adapted for standalone use
+with minimal dependencies — PIL only for background removal, no hard
+OpenCV requirement.
+
+Author:  Gero Doll / Limbicnation
+License: Apache-2.0
+"""
+
+from __future__ import annotations
+
+import structlog
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+from PIL import Image
+
+log = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# ComfyUI import guards
+# ---------------------------------------------------------------------------
+try:
+    import comfy.utils
+
+    _COMFY_AVAILABLE = True
+except ImportError:
+    _COMFY_AVAILABLE = False
+    log.info("RemoveBackgroundAndResizeNode.comfyui_unavailable")
+
+# ---------------------------------------------------------------------------
+# ScalingMixin — shared resize logic (from grabcut_nodes.py)
+# ---------------------------------------------------------------------------
+
+class ScalingMixin:
+    """
+    Provides deterministic resize helpers with power-of-8 size support.
+    Mix into any node class that needs resize.
+    """
+
+    _RESAMPLING_MAP = {
+        "NEAREST": Image.Resampling.NEAREST,
+        "BILINEAR": Image.Resampling.BILINEAR,
+        "BICUBIC": Image.Resampling.BICUBIC,
+        "LANCZOS": Image.Resampling.LANCZOS,
+    }
+
+    @staticmethod
+    def _parse_size(size_str: str) -> Optional[Tuple[int, int]]:
+        """Parse ``WIDTHxHEIGHT`` string → ``(w, h)`` or ``None`` for ORIGINAL."""
+        if size_str == "ORIGINAL":
+            return None
+        try:
+            w, h = size_str.lower().split("x")
+            return int(w), int(h)
+        except (ValueError, AttributeError):
+            raise ValueError(f"Invalid size format: {size_str!r}. Use WxH or ORIGINAL.")
+
+    @staticmethod
+    def _scale_factor(current: Tuple[int, int], target: Tuple[int, int]) -> float:
+        """Smallest scale that fits image inside target, preserving aspect."""
+        sw = target[0] / current[0]
+        sh = target[1] / current[1]
+        return min(sw, sh)
+
+    # ------------------------------------------------------------------
+    # public helpers (override in node class if you need custom behaviour)
+    # ------------------------------------------------------------------
+    def resize_image(
+        self,
+        image: Image.Image,
+        size_str: str,
+        method: str = "LANCZOS",
+    ) -> Image.Image:
+        """
+        Resize ``image`` to fit inside the dimensions described by ``size_str``.
+
+        Uses ``Image.resize`` with the selected interpolation method.
+        When ``size_str == "ORIGINAL`` the image is returned unchanged.
+        """
+        if size_str == "ORIGINAL":
+            return image
+
+        target = self._parse_size(size_str)
+        if target is None:
+            return image  # should not reach
+
+        cur = (image.width, image.height)
+        if cur == target:
+            return image
+
+        factor = self._scale_factor(cur, target)
+        new_w = max(1, int(image.width * factor))
+        new_h = max(1, int(image.height * factor))
+
+        resample = self._RESAMPLING_MAP.get(method.upper(), Image.Resampling.LANCZOS)
+        return image.resize((new_w, new_h), resample)
+
+
+# ---------------------------------------------------------------------------
+# PIL-only background removal
+# ---------------------------------------------------------------------------
+
+def _kmeans_colors(
+    arr: np.ndarray, n_clusters: int, tol: float = 0.01, max_iter: int = 20
+) -> np.ndarray:
+    """
+    Simple k-means on pixel array [H*W, channels].
+    Returns ``(n_clusters, channels)`` cluster centres.
+    Fallback when scikit-learn is unavailable.
+    """
+    pixels = arr.reshape(-1, arr.shape[-1]).astype(np.float32)
+    indices = np.random.RandomState(42).choice(
+        len(pixels), size=n_clusters, replace=False
+    )
+    centres = pixels[indices].copy()
+
+    for _ in range(max_iter):
+        dists = np.linalg.norm(pixels[:, None] - centres[None], axis=-1)
+        labels = dists.argmin(axis=1)
+        new_centres = np.stack([pixels[labels == i].mean(axis=0) for i in range(n_clusters)])
+        if np.abs(new_centres - centres).max() < tol:
+            break
+        centres = new_centres
+
+    return centres
+
+
+def _dominant_bg(arr: np.ndarray, samples: int = 5000) -> np.ndarray:
+    """Sample corners + border to estimate background colour."""
+    h, w = arr.shape[:2]
+    mask = np.zeros((h, w), dtype=bool)
+    bw = max(1, min(h, w) // 10)
+
+    # top / bottom strips and left / right strips (intersection gives the four corners)
+    mask[:bw, :] = True
+    mask[-bw:, :] = True
+    mask[:, :bw] = True
+    mask[:, -bw:] = True
+
+    bg_pixels = arr[mask]
+    if len(bg_pixels) > samples:
+        idx = np.random.RandomState(42).choice(len(bg_pixels), samples, replace=False)
+        bg_pixels = bg_pixels[idx]
+
+    return bg_pixels.mean(axis=0).astype(np.uint8)
+
+
+def remove_background_pil(
+    image: Image.Image,
+    tolerance: int = 30,
+    edge_sensitivity: float = 0.8,
+    color_clusters: int = 8,
+    foreground_bias: float = 0.7,
+    binary_threshold: int = 128,
+    dither_handling: bool = True,
+) -> Image.Image:
+    """
+    Remove background from a PIL Image using colour clustering.
+
+    Pipeline
+    --------
+    1. Flatten to ``[H*W, channels]`` and run k-means to find dominant colours.
+    2. Identify background as the colour most similar to image edges / corners.
+    3. Compute per-pixel distance to foreground centres; keep pixels that are
+       closer than ``tolerance`` (adjusted by ``foreground_bias``).
+    4. Apply simple edge refinement via binary thresholding.
+    5. Return ``RGBA`` PIL Image.
+
+    Parameters
+    ----------
+    image : PIL.Image
+        Input image (RGB or RGBA; RGBA ``A`` is ignored).
+    tolerance : int
+        Colour distance threshold (0-255). Higher = more pixels accepted as foreground.
+    edge_sensitivity : float
+        Fraction of edge region sampled for background estimation (0-1).
+    color_clusters : int
+        K-means centres used to identify distinct colours.
+    foreground_bias : float
+        Bias towards keeping pixels (0 = discard more, 1 = keep more).
+    binary_threshold : int
+        Threshold for alpha mask binarisation (0-255).
+    dither_handling : bool
+        When True, apply a 1-pixel border erosion to reduce dither artefacts.
+
+    Returns
+    -------
+    PIL.Image
+        RGBA image with transparent background.
+    """
+    rgb = image.convert("RGB")
+    arr = np.array(rgb, dtype=np.float32)  # [H, W, 3]
+
+    # 1. k-means colour clustering
+    if color_clusters < 2:
+        color_clusters = 2
+    centres = _kmeans_colors(arr, color_clusters)
+
+    # 2. background colour from image perimeter
+    bg_colour = _dominant_bg(arr)
+
+    # 3. distance of each pixel to background vs foreground centres
+    h, w = arr.shape[:2]
+    flat = arr.reshape(-1, 3)
+
+    bg_dist = np.linalg.norm(flat - bg_colour.astype(np.float32), axis=1)
+    fg_dist = np.linalg.norm(
+        flat[:, None] - centres.astype(np.float32), axis=-1
+    ).min(axis=1)
+
+    # effective tolerance — foreground_bias shifts the acceptance boundary
+    effective_tol = tolerance * (1.5 - foreground_bias)
+    mask = (fg_dist + effective_tol) < bg_dist
+
+    alpha = mask.reshape(h, w).astype(np.uint8) * 255
+
+    # 4. edge refinement
+    if dither_handling:
+        from PIL import ImageFilter
+
+        alpha_pil = Image.fromarray(alpha, mode="L")
+        alpha_pil = alpha_pil.filter(ImageFilter.MinFilter(3))
+        alpha = np.array(alpha_pil)
+
+    # 5. binarise
+    alpha = (alpha > binary_threshold).astype(np.uint8) * 255
+
+    # 6. assemble RGBA
+    result = np.dstack([arr.astype(np.uint8), alpha])
+    return Image.fromarray(result, mode="RGBA")
+
+
+# ---------------------------------------------------------------------------
+# ComfyUI node
+# ---------------------------------------------------------------------------
+
+class RemoveBackgroundAndResizeNode(ScalingMixin):
+    """
+    Combines background removal and resize in a single node.
+
+    ``INPUT_TYPES`` exposes tolerance, edge sensitivity, colour-cluster, and
+    output-size controls so the node can be dropped into any workflow without
+    separate background-removal and resize chains.
+
+    Outputs
+    -------
+    IMAGE : RGBA tensor (N, H, W, 4), values 0-1
+    MASK  : greyscale alpha tensor (N, H, W),    values 0-1
+    """
+
+    # ------------------------------------------------------------------
+    # ComfyUI contract
+    # ------------------------------------------------------------------
+    RETURN_TYPES = ("IMAGE", "MASK")
+    RETURN_NAMES = ("image", "mask")
+    FUNCTION = "process"
+    CATEGORY = "image/processing"
+    OUTPUT_NODE = False
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": ("IMAGE", {"tooltip": "Input image tensor from upstream node"}),
+                "tolerance": (
+                    "INT",
+                    {
+                        "default": 30,
+                        "min": 0,
+                        "max": 255,
+                        "step": 1,
+                        "display": "number",
+                        "tooltip": (
+                            "Colour distance threshold. Higher = more aggressive "
+                            "foreground extraction (0-255)."
+                        ),
+                    },
+                ),
+                "foreground_bias": (
+                    "FLOAT",
+                    {
+                        "default": 0.7,
+                        "min": 0.0,
+                        "max": 1.0,
+                        "step": 0.01,
+                        "display": "slider",
+                        "tooltip": (
+                            "Bias toward keeping pixels as foreground. "
+                            "Higher = more pixels preserved."
+                        ),
+                    },
+                ),
+                "color_clusters": (
+                    "INT",
+                    {
+                        "default": 8,
+                        "min": 2,
+                        "max": 20,
+                        "step": 1,
+                        "display": "number",
+                        "tooltip": "Number of k-means centres for colour segmentation.",
+                    },
+                ),
+                "output_size": (
+                    [
+                        "ORIGINAL",
+                        "512x512",
+                        "768x768",
+                        "1024x1024",
+                        "1280x720",
+                        "1920x1080",
+                    ],
+                    {
+                        "default": "ORIGINAL",
+                        "tooltip": (
+                            "Resize output to this size. "
+                            "ORIGINAL keeps source dimensions."
+                        ),
+                    },
+                ),
+                "scaling_method": (
+                    ["NEAREST", "BILINEAR", "BICUBIC", "LANCZOS"],
+                    {
+                        "default": "LANCZOS",
+                        "tooltip": (
+                            "Interpolation method. "
+                            "LANCZOS = best quality; "
+                            "NEAREST = pixel-perfect for pixel art."
+                        ),
+                    },
+                ),
+            },
+            "optional": {
+                "dither_handling": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "Apply edge erosion to suppress dither artefacts.",
+                    },
+                ),
+                "binary_threshold": (
+                    "INT",
+                    {
+                        "default": 128,
+                        "min": 0,
+                        "max": 255,
+                        "step": 1,
+                        "display": "number",
+                        "tooltip": "Alpha mask binarisation cutoff (0-255).",
+                    },
+                ),
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # processing
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def process(
+        self,
+        image: torch.Tensor,
+        tolerance: int,
+        foreground_bias: float,
+        color_clusters: int,
+        output_size: str,
+        scaling_method: str,
+        dither_handling: bool = True,
+        binary_threshold: int = 128,
+    ) -> Tuple[Tuple[torch.Tensor, torch.Tensor]]:
+        """
+        ``image`` — ComfyUI IMAGE tensor, shape (N, H, W, C), float32 0-1.
+        Returns (IMAGE tensor, MASK tensor).
+        """
+        # ------------------------------------------------------------------
+        # validation
+        # ------------------------------------------------------------------
+        if image is None or image.numel() == 0:
+            raise ValueError("RemoveBackgroundAndResizeNode: received empty image tensor.")
+        if image.ndim != 4:
+            raise ValueError(
+                f"RemoveBackgroundAndResizeNode: expected 4-D IMAGE tensor "
+                f"(N,H,W,C), got {image.ndim}-D."
+            )
+        if image.shape[-1] not in (3, 4):
+            raise ValueError(
+                f"RemoveBackgroundAndResizeNode: IMAGE must be RGB or RGBA; "
+                f"got channels={image.shape[-1]}."
+            )
+
+        # ------------------------------------------------------------------
+        # per-batch processing
+        # ------------------------------------------------------------------
+        rgba_tensors: list[torch.Tensor] = []
+        mask_tensors: list[torch.Tensor] = []
+
+        for i in range(image.shape[0]):
+            img_np = (image[i].cpu().numpy() * 255).clip(0, 255).astype(np.uint8)
+
+            # handle RGB input
+            if img_np.shape[-1] == 3:
+                pil_in = Image.fromarray(img_np, mode="RGB")
+            else:
+                pil_in = Image.fromarray(img_np[:, :, :3], mode="RGB")
+
+            # ---- remove background ----
+            pil_rgba = remove_background_pil(
+                pil_in,
+                tolerance=tolerance,
+                foreground_bias=foreground_bias,
+                color_clusters=color_clusters,
+                binary_threshold=binary_threshold,
+                dither_handling=dither_handling,
+            )
+
+            # ---- resize ----
+            pil_rgba = self.resize_image(pil_rgba, output_size, scaling_method)
+
+            # ---- back to tensor ----
+            arr = np.array(pil_rgba, dtype=np.float32) / 255.0
+            rgba_tensors.append(torch.from_numpy(arr))
+
+            # extract alpha channel as mask
+            mask_np = (np.array(pil_rgba.split()[3], dtype=np.float32) / 255.0)
+            mask_tensors.append(torch.from_numpy(mask_np))
+
+        # ------------------------------------------------------------------
+        # stack and return in ComfyUI tensor format
+        # ------------------------------------------------------------------
+        stacked_image: torch.Tensor = torch.stack(rgba_tensors).to(dtype=torch.float32)
+        stacked_mask: torch.Tensor = torch.stack(mask_tensors).to(dtype=torch.float32)
+
+        # ComfyUI MASK convention: (N, H, W)
+        if stacked_mask.ndim == 4 and stacked_mask.shape[-1] == 1:
+            stacked_mask = stacked_mask.squeeze(-1)
+
+        log.debug(
+            "RemoveBackgroundAndResizeNode.done",
+            batch=image.shape[0],
+            output_size=output_size,
+            scaling_method=scaling_method,
+        )
+
+        return (stacked_image, stacked_mask)
+
+
+# ComfyUI registration dict
+NODE_CLASS_MAPPINGS = {"RemoveBackgroundAndResize": RemoveBackgroundAndResizeNode}
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "RemoveBackgroundAndResize": "Remove Background & Resize"
+}

--- a/__init__.py
+++ b/__init__.py
@@ -18,6 +18,21 @@ except ImportError:
 # Import main transparency background remover nodes
 from .nodes import NODE_CLASS_MAPPINGS as NODES_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS as NODES_DISPLAY_MAPPINGS
 
+# Import standalone RemoveBackgroundAndResizeNode
+try:
+    from .RemoveBackgroundAndResizeNode import (
+        NODE_CLASS_MAPPINGS as REMBG_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS as REMBG_DISPLAY_MAPPINGS,
+    )
+    REMBG_AVAILABLE = True
+except Exception as e:
+    REMBG_MAPPINGS = {}
+    REMBG_DISPLAY_MAPPINGS = {}
+    REMBG_AVAILABLE = False
+    print("\n" + "="*70)
+    print("ℹ️  RemoveBackgroundAndResizeNode unavailable:", str(e))
+    print("="*70 + "\n")
+
 # Try to import GrabCut nodes (optional - requires ultralytics)
 try:
     from .grabcut_nodes import NODE_CLASS_MAPPINGS as GRABCUT_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS as GRABCUT_DISPLAY_MAPPINGS
@@ -37,8 +52,8 @@ except ImportError as e:
     print("\nMain background remover nodes are still available!")
     print("="*70 + "\n")
 
-# Combine node mappings from both modules
-NODE_CLASS_MAPPINGS = {**NODES_MAPPINGS, **GRABCUT_MAPPINGS}
-NODE_DISPLAY_NAME_MAPPINGS = {**NODES_DISPLAY_MAPPINGS, **GRABCUT_DISPLAY_MAPPINGS}
+# Combine node mappings from all modules
+NODE_CLASS_MAPPINGS = {**NODES_MAPPINGS, **GRABCUT_MAPPINGS, **REMBG_MAPPINGS}
+NODE_DISPLAY_NAME_MAPPINGS = {**NODES_DISPLAY_MAPPINGS, **GRABCUT_DISPLAY_MAPPINGS, **REMBG_DISPLAY_MAPPINGS}
 
 __all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']

--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@ try:
         NODE_DISPLAY_NAME_MAPPINGS as REMBG_DISPLAY_MAPPINGS,
     )
     REMBG_AVAILABLE = True
-except Exception as e:
+except ImportError as e:
     REMBG_MAPPINGS = {}
     REMBG_DISPLAY_MAPPINGS = {}
     REMBG_AVAILABLE = False

--- a/grabcut_nodes.py
+++ b/grabcut_nodes.py
@@ -40,21 +40,21 @@ except ImportError:
     validate_node_params = GrabCutParams = MaskParams = None
 
 
-class ScalingMixin:
+# Import shared ScalingMixin base and extend with GrabCut-specific methods
+try:
+    from .scaling import ScalingMixin as _BaseScalingMixin
+except ImportError:
+    from scaling import ScalingMixin as _BaseScalingMixin
+
+
+class ScalingMixin(_BaseScalingMixin):
     """
-    Mixin class providing shared scaling functionality for GrabCut nodes.
-    Eliminates code duplication and improves performance.
+    Extended ScalingMixin for GrabCut nodes.
+
+    Inherits core resize helpers from ``scaling.ScalingMixin`` and adds
+    GrabCut-specific methods: ``parse_output_size``, ``intelligent_scale``,
+    and ``_apply_resize``.
     """
-    
-    # Class-level constants
-    
-    # Class-level resampling map to avoid recreation on every call
-    _RESAMPLING_MAP = {
-        "NEAREST": Image.Resampling.NEAREST,
-        "BILINEAR": Image.Resampling.BILINEAR,
-        "BICUBIC": Image.Resampling.BICUBIC,
-        "LANCZOS": Image.Resampling.LANCZOS
-    }
     
     @staticmethod
     def parse_output_size(size_string: str) -> Optional[Tuple[int, int]]:
@@ -84,9 +84,7 @@ class ScalingMixin:
         Calculate optimal scaling factor while preserving aspect ratio.
         
         Uses the smaller of width/height scale factors to ensure the scaled image
-        fits within target dimensions without exceeding them. This means the final
-        image may be smaller than target_size in one dimension to maintain the
-        original aspect ratio.
+        fits within target dimensions without exceeding them.
         
         Args:
             current_size: Tuple (width, height) of current image
@@ -94,21 +92,12 @@ class ScalingMixin:
             
         Returns:
             Scaling factor that preserves aspect ratio and fits within target_size
-            
-        Example:
-            current_size=(100, 200), target_size=(150, 150)
-            -> scale_w=1.5, scale_h=0.75, returns min(1.5, 0.75) = 0.75
-            -> final size would be (75, 150) to preserve aspect ratio
         """
         current_w, current_h = current_size
         target_w, target_h = target_size
         
-        # Calculate scale factors for width and height
         scale_w = target_w / current_w
         scale_h = target_h / current_h
-        
-        # Use the same scale for both dimensions to maintain aspect ratio
-        # Choose the smaller scale to ensure we don't exceed target dimensions
         scale_factor = min(scale_w, scale_h)
         
         return scale_factor
@@ -120,7 +109,7 @@ class ScalingMixin:
         Args:
             image_pil: PIL Image object
             target_size: Tuple (width, height) for target dimensions
-            scaling_method: Interpolation method ("NEAREST", "BILINEAR", "BICUBIC", "LANCZOS")
+            scaling_method: Interpolation method (\"NEAREST\", \"BILINEAR\", \"BICUBIC\", \"LANCZOS\")
             
         Returns:
             Scaled PIL Image
@@ -130,21 +119,14 @@ class ScalingMixin:
             
         current_size = (image_pil.width, image_pil.height)
         
-        # If already at target size, return as-is
         if current_size == target_size:
             return image_pil
         
-        # Calculate scaling factor
         scale_factor = self.calculate_scaling_factor(current_size, target_size)
         
-        # Apply scaling
         new_width = int(image_pil.width * scale_factor)
         new_height = int(image_pil.height * scale_factor)
         
-        # Note: Removed dimension snapping to preserve perfect aspect ratio
-        # The scaled image will fit within target dimensions, potentially smaller on one axis
-        
-        # Use class-level resampling map for better performance
         resampling_method = self._RESAMPLING_MAP.get(scaling_method.upper(), Image.Resampling.NEAREST)
         
         return image_pil.resize(
@@ -170,7 +152,6 @@ class ScalingMixin:
         if output_size == "ORIGINAL":
             return image_np
         
-        # Parse target dimensions
         if output_size == "custom":
             target_dimensions = (custom_width, custom_height)
         else:
@@ -179,13 +160,9 @@ class ScalingMixin:
         if target_dimensions is None:
             return image_np
         
-        # Convert to PIL Image for scaling
         image_pil = Image.fromarray(image_np, 'RGBA')
-        
-        # Apply intelligent scaling with specified method
         scaled_pil = self.intelligent_scale(image_pil, target_dimensions, scaling_method)
         
-        # Convert back to numpy
         return np.array(scaled_pil)
 
 

--- a/scaling.py
+++ b/scaling.py
@@ -1,0 +1,83 @@
+"""
+scaling
+=======
+Shared resize logic for ComfyUI custom nodes.
+
+Provides ``ScalingMixin`` — a mixin class with deterministic resize helpers
+and power-of-8 size support.  Used by both ``RemoveBackgroundAndResizeNode``
+and ``grabcut_nodes.py`` to avoid code duplication.
+
+Author:  Gero Doll / Limbicnation
+License: Apache-2.0
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from PIL import Image
+
+
+class ScalingMixin:
+    """
+    Provides deterministic resize helpers with power-of-8 size support.
+    Mix into any node class that needs resize.
+    """
+
+    _RESAMPLING_MAP = {
+        "NEAREST": Image.Resampling.NEAREST,
+        "BILINEAR": Image.Resampling.BILINEAR,
+        "BICUBIC": Image.Resampling.BICUBIC,
+        "LANCZOS": Image.Resampling.LANCZOS,
+    }
+
+    @staticmethod
+    def _parse_size(size_str: str) -> Optional[Tuple[int, int]]:
+        """Parse ``WIDTHxHEIGHT`` string → ``(w, h)`` or ``None`` for ORIGINAL."""
+        if size_str == "ORIGINAL":
+            return None
+        try:
+            w, h = size_str.lower().split("x")
+            return int(w), int(h)
+        except (ValueError, AttributeError):
+            raise ValueError(f"Invalid size format: {size_str!r}. Use WxH or ORIGINAL.")
+
+    @staticmethod
+    def _scale_factor(current: Tuple[int, int], target: Tuple[int, int]) -> float:
+        """Smallest scale that fits image inside target, preserving aspect."""
+        sw = target[0] / current[0]
+        sh = target[1] / current[1]
+        return min(sw, sh)
+
+    # ------------------------------------------------------------------
+    # public helpers (override in node class if you need custom behaviour)
+    # ------------------------------------------------------------------
+    def resize_image(
+        self,
+        image: Image.Image,
+        size_str: str,
+        method: str = "LANCZOS",
+    ) -> Image.Image:
+        """
+        Resize ``image`` to fit inside the dimensions described by ``size_str``.
+
+        Uses ``Image.resize`` with the selected interpolation method.
+        When ``size_str == "ORIGINAL"`` the image is returned unchanged.
+        """
+        if size_str == "ORIGINAL":
+            return image
+
+        target = self._parse_size(size_str)
+        if target is None:
+            return image  # should not reach
+
+        cur = (image.width, image.height)
+        if cur == target:
+            return image
+
+        factor = self._scale_factor(cur, target)
+        new_w = max(1, int(image.width * factor))
+        new_h = max(1, int(image.height * factor))
+
+        resample = self._RESAMPLING_MAP.get(method.upper(), Image.Resampling.LANCZOS)
+        return image.resize((new_w, new_h), resample)


### PR DESCRIPTION
…und removal with resize

- Single-file node combining background removal + resize (no external background_remover.py dependency)
- PIL-only implementation: k-means colour clustering, dominant-bg estimation from edges, alpha binarisation
- ScalingMixin from grabcut_nodes.py: power-of-8 resize, 6 preset sizes + ORIGINAL
- ComfyUI contract: INPUT_TYPES, RETURN_TYPES (IMAGE + MASK), FUNCTION, CATEGORY
- Registered in __init__.py alongside existing TransparencyBackgroundRemover and GrabCut nodes
- structlog logging, torch.no_grad() guard, full validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Remove Background & Resize" node for ComfyUI, combining background removal and image resizing in a single operation with configurable parameters for tolerance, color clustering, output size, and scaling interpolation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->